### PR TITLE
Add success toast and event emission for profile field updates

### DIFF
--- a/components/case/panelProfileVaultInformation/index.tsx
+++ b/components/case/panelProfileVaultInformation/index.tsx
@@ -18,6 +18,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { Loader2Icon } from 'lucide-react';
 import { memo, useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
 import { z } from 'zod';
 
 const StatusMap: Record<string, string> = {
@@ -74,10 +75,7 @@ const PurePanelProfileVaultInformationItem = ({
           if (fields.some(field => field.fieldPath === curr[0])) {
             return {
               ...prev,
-              [curr[0].replaceAll('-', '.')]: {
-                value: curr[1],
-                operation: 'SET',
-              },
+              [curr[0].replaceAll('-', '.')]: curr[1],
             };
           } else {
             return prev;
@@ -85,12 +83,13 @@ const PurePanelProfileVaultInformationItem = ({
         },
         {} as Record<string, any>
       );
-      console.log(params);
-      const res = await updateMultipleProfileFields(caseId, { fieldUpdates: params });
+      const res = await updateMultipleProfileFields(caseId, params);
       emit({
         type: 'update-case-detail',
       });
-      console.log(res);
+      if (res.successfulResults.length > 0) {
+        toast.success('Updated successfully');
+      }
       setEditMode(false);
     } catch (error) {
       console.error(error);

--- a/service/api/case.ts
+++ b/service/api/case.ts
@@ -26,13 +26,13 @@ import {
 } from '../mock/case';
 
 const IS_MOCK_LIST: string[] = [
-  // 'createCase',
-  // 'getWorkflowDefinitions',
+  'createCase',
+  'getWorkflowDefinitions',
   // 'queryCaseList',
   // 'queryCaseDetail',
-  // 'getWorkflowList',
-  // 'caseStream',
-  // 'uploadDocument',
+  'getWorkflowList',
+  'caseStream',
+  'uploadDocument',
 ];
 
 const CaseApi = {
@@ -341,10 +341,8 @@ export const removeDocument = async (caseId: string, documentId: string) => {
 
 export const updateMultipleProfileFields = async (
   caseId: string,
-  params: {
-    fieldUpdates: Record<string, string>;
-  }
-) => {
+  params: Record<string, string>
+): Promise<{ successfulResults: any[] }> => {
   return ApiRequest.put(
     `${baseUrl}${CaseApi.profileFields.replace(':caseId', caseId)}`,
     params


### PR DESCRIPTION
- Show toast on successful field updates in DynamicForm and InformationItem
- Emit update event when canceling edit in DynamicForm
- Simplify updateMultipleProfileFields API params structure
- Filter out 'id' field in dynamic form rendering
- Toggle mock APIs for testing