### PR TITLE
Update profile vault tab content to use schema definitions

### DIFF
--- a/app/(root)/layout.tsx
+++ b/app/(root)/layout.tsx
@@ -63,7 +63,7 @@ export default function RootLayout({
             labelFontSize: 14,
           },
           Breadcrumb: {
-            separatorMargin: 4,
+            separatorMargin: 2,
             ...(isDarkMode
               ? {
                   lastItemColor: '#f0f0f0',

--- a/components/case/panelProfileVault/index.tsx
+++ b/components/case/panelProfileVault/index.tsx
@@ -98,12 +98,12 @@ function PurePanelProfileVault(props: PanelProfileVaultProps) {
     });
   };
 
-  const getTabList = (profileDummyData: ICaseItemType['profileDummyData']) => {
-    if (!profileDummyData) return [];
-    return Object.keys(profileDummyData)
+  const getTabList = (properties: Record<string, { 'x-displayName': string }>) => {
+    if (!properties) return [];
+    return Object.keys(properties)
       .map(key => ({
         value: key,
-        label: camelToCapitalizedWords(key),
+        label: properties[key]['x-displayName'] ?? camelToCapitalizedWords(key),
       }))
       .sort((a, b) => a.value.localeCompare(b.value));
   };
@@ -186,16 +186,18 @@ function PurePanelProfileVault(props: PanelProfileVaultProps) {
             </TabsContent>
             {tabList
               .filter(tab => tab.value !== 'overview')
-              .map(({ value }) => (
-                <TabsContent value={value} key={value}>
-                  <PanelProfileVaultTabContent
-                    fieldKey={value}
-                    data={caseInfo?.profileDummyData?.[value] as Record<string, any>}
-                    caseId={caseInfo.id}
-                    dummyDataFields={caseInfo?.dummyDataFields as any[]}
-                  />
-                </TabsContent>
-              ))}
+              .map(({ value }) => {
+                return (
+                  <TabsContent value={value} key={value}>
+                    <PanelProfileVaultTabContent
+                      fieldKey={value}
+                      data={caseInfo?.profileDummyData?.[value] as Record<string, any>}
+                      caseId={caseInfo.id}
+                      dummyDataFields={caseInfo?.dummyDataFields as any[]}
+                    />
+                  </TabsContent>
+                );
+              })}
           </Tabs>
         </div>
       ) : (


### PR DESCRIPTION
Refactor profile vault tab content to:
- Use schema definitions for form structure
- Simplify data handling by removing custom section analysis
- Improve field key handling and dummy data display
- Remove feCustom special case handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reduced spacing around the breadcrumb separator for a more compact appearance.

* **Refactor**
  * Simplified and streamlined the logic for generating tab labels in the profile vault, improving label clarity and code maintainability.
  * Refactored profile vault tab content and editor components to directly use schema definitions from the store, removing unnecessary data transformations and simplifying data flow.
  * Improved key tracking and display consistency in dynamic profile sections, especially for nested and boolean values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->