### PR TITLE
Update tab list generation to use new schema properties format

### DIFF
--- a/components/case/panelProfileVault/index.tsx
+++ b/components/case/panelProfileVault/index.tsx
@@ -55,12 +55,14 @@ function PurePanelProfileVault(props: PanelProfileVaultProps) {
     }
   }, [caseInfo, getMissingFieldsEmail]);
 
-  const getTabList = (properties: Record<string, { 'x-displayName': string }>) => {
+  const getTabList = (properties: Record<string, { title: string; $ref: string }>) => {
     if (!properties) return [];
-    return Object.keys(properties)
-      .map(key => ({
+    return Object.entries(properties)
+      .map(([key, value]) => ({
+        ...value,
         value: key,
-        label: properties[key]['x-displayName'] ?? camelToCapitalizedWords(key),
+        label: value['title'] ?? camelToCapitalizedWords(key),
+        definitionKey: (value['$ref'] ?? '').replace('#/definitions/', ''),
       }))
       .sort((a, b) => a.value.localeCompare(b.value));
   };
@@ -116,11 +118,12 @@ function PurePanelProfileVault(props: PanelProfileVaultProps) {
             </TabsContent>
             {tabList
               .filter(tab => tab.value !== 'overview')
-              .map(({ value }) => {
+              .map(({ value, definitionKey }) => {
                 return (
                   <TabsContent value={value} key={value}>
                     <PanelProfileVaultTabContent
                       fieldKey={value}
+                      definitionKey={definitionKey}
                       data={caseInfo?.profileDummyData?.[value] as Record<string, any>}
                       caseId={caseInfo.id}
                       dummyDataFields={caseInfo?.dummyDataFields as any[]}

--- a/components/case/panelProfileVaultTabContent/index.tsx
+++ b/components/case/panelProfileVaultTabContent/index.tsx
@@ -6,14 +6,7 @@ import { useEventManager } from '@/hooks/useEventManager';
 import { camelToCapitalizedWords } from '@/lib';
 import { updateProfileField } from '@/service/api';
 import { useProfileStore } from '@/store/profileStore';
-import {
-  isArray,
-  isBoolean,
-  isNumber,
-  isPlainObject,
-  isString,
-  upperFirst,
-} from 'lodash';
+import { isArray, isBoolean, isNumber, isPlainObject, isString } from 'lodash';
 import { Loader2Icon } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
@@ -22,6 +15,7 @@ type PanelProfileVaultTabContentProps = {
   fieldKey: string;
   data: Record<string, any>;
   caseId: string;
+  definitionKey: string;
   dummyDataFields?: string[];
 };
 
@@ -29,6 +23,7 @@ export const PanelProfileVaultTabContent = ({
   fieldKey,
   data,
   caseId,
+  definitionKey,
   dummyDataFields,
 }: PanelProfileVaultTabContentProps) => {
   const { schema } = useProfileStore();
@@ -36,8 +31,7 @@ export const PanelProfileVaultTabContent = ({
 
   useEffect(() => {
     if (schema?.jsonSchema?.definitions) {
-      const schemaKey = upperFirst(fieldKey);
-      const definition = schema.jsonSchema.definitions[schemaKey];
+      const definition = schema.jsonSchema.definitions[definitionKey];
       if (definition) {
         setCurrentSchema({
           ...definition,
@@ -45,7 +39,7 @@ export const PanelProfileVaultTabContent = ({
         });
       }
     }
-  }, [schema, fieldKey]);
+  }, [schema, definitionKey]);
 
   return (
     <div className="w-full">

--- a/components/case/panelReference/index.tsx
+++ b/components/case/panelReference/index.tsx
@@ -205,7 +205,8 @@ function PurePanelReference(props: PanelReferenceProps) {
         {isFileLoading ? (
           <div className="w-full h-full flex flex-col justify-center items-center text-primary">
             <IconLogo size={24} className="animate-spin mb-2 animation-duration-[2s]" />
-            <p className="after:animate-point-loading">Loading</p>
+
+            {!isFold && <p className="after:animate-point-loading">Loading</p>}
           </div>
         ) : (
           <div className="flex flex-col gap-8">


### PR DESCRIPTION
The schema properties now include 'title' and '$ref' fields instead of 'x-displayName'. This change updates the tab list generation to handle the new format and pass the definitionKey to tab content components.